### PR TITLE
1.0.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,15 +35,16 @@ To Upload a file, use the `WaifuApi::uploadFile` function.
 
 The function accepts an **associative array** of arguments.
 
-| Param (key)     | Type      | Description                                                                        | Required                                               | Extra info                                             |
-|-----------------|-----------|------------------------------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------|
-| `file`          | `string`  | The file path to upload                                                            | true only if `url` or `file_contents` is not supplied  | If `url` is supplied, this prop can't be set           |
-| `url`           | `string`  | The URL to a file that exists on the internet                                      | true only if `file` or `file_contents` is not supplied | If `url` is supplied, this prop has no effect          |
-| `file_contents` | `string`  | The file contents                                                                  | true only if `url` or `file` is not supplied           | If `url` or `file` is supplied, this prop can't be set |
-| `expires`       | `string`  | A string containing a number and a unit (1d = 1day)                                | false                                                  | Valid units are `m`, `h` and `d`                       |
-| `hideFilename`  | `boolean` | If true, then the uploaded filename won't appear in the URL                        | false                                                  | Defaults to `false`                                    |
-| `password`      | `string`  | If set, then the uploaded file will be encrypted                                   | false                                                  |                                                        |
-| `filename`      | `string`  | Only used if `file_contents` or `file` is set, will set the filename of the upload | false                                                  |                                                        |
+| Param (key)        | Type       | Description                                                                        | Required                                               | Extra info                                             |
+|--------------------|------------|------------------------------------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------|
+| `file`             | `string`   | The file path to upload                                                            | true only if `url` or `file_contents` is not supplied  | If `url` is supplied, this prop can't be set           |
+| `url`              | `string`   | The URL to a file that exists on the internet                                      | true only if `file` or `file_contents` is not supplied | If `url` is supplied, this prop has no effect          |
+| `file_contents`    | `string`   | The file contents                                                                  | true only if `url` or `file` is not supplied           | If `url` or `file` is supplied, this prop can't be set |
+| `expires`          | `string`   | A string containing a number and a unit (1d = 1day)                                | false                                                  | Valid units are `m`, `h` and `d`                       |
+| `hideFilename`     | `boolean`  | If true, then the uploaded filename won't appear in the URL                        | false                                                  | Defaults to `false`                                    |
+| `password`         | `string`   | If set, then the uploaded file will be encrypted                                   | false                                                  |                                                        |
+| `filename`         | `string`   | Only used if `file_contents` or `file` is set, will set the filename of the upload | false                                                  |                                                        |
+| `oneTimeDownload	` | `boolean`  | If true, the file is deleted after the first access	                               | false                                                  |                                                        |
 
 #### WaifuResponse Return value<a id="waifuresponse-object"></a>
 
@@ -54,8 +55,12 @@ The function returns a `WaifuResponse` object, throws and `Exception` or `WaifuE
 ErnestMarcinko\WaifuVault\WaifuResponse (4) {
   ["token"]=> string(36) "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
   ["url"]=> string(74) "https://waifuvault.moe/f/{timestamp}/{filename}.{file_ext}"
-  ["protected"]=> bool(true)
-  ["retentionPeriod"]=> string(39) "334 days 20 hours 16 minutes 23 seconds"
+  ["retentionPeriod"]=> string(39) "334 days 20 hours 16 minutes 23 seconds",
+  ["options"] ErnestMarcinko\WaifuVault\WaifuResponseOptions (4) {
+	["hideFilename"]=> bool(false),
+	["oneTimeDownload"]=> bool(false),
+	["protected"]=> bool(false),
+  }
 }
 ```
 

--- a/src/WaifuApi.php
+++ b/src/WaifuApi.php
@@ -25,7 +25,13 @@ use CURLStringFile;
  *     url: string
  * }
  *
- * @phpstan-type uploadFileArg FileUpload|FileContentUpload|UrlUpload
+ * @phpstan-type uploadFileArg array{
+ *     expires?:string,
+ *     hide_filename?:bool,
+ *     password?:string,
+ *     one_time_download?:bool
+ * }&(FileUpload|FileContentUpload|UrlUpload)
+ *
  * @phpstan-type modifyFileArg array{
  *     token: string,
  *     password?: string,
@@ -63,7 +69,8 @@ class WaifuApi {
 				return in_array($k, array(
 						'expires',
 						'hide_filename',
-						'password')) && !is_null($v); // @phpstan-ignore-line
+						'password',
+						'one_time_download')) && !is_null($v); // @phpstan-ignore-line
 			},
 			ARRAY_FILTER_USE_BOTH
 		));

--- a/src/WaifuApi.php
+++ b/src/WaifuApi.php
@@ -63,7 +63,7 @@ class WaifuApi {
 	public function uploadFile(array $args): WaifuResponse {
 		$post_fields = [];
 		$url = self::REST_URL;
-		$params = http_build_query(array_filter(
+		$params = array_filter(
 			$args,
 			function ($v, $k) {
 				return in_array($k, array(
@@ -73,10 +73,19 @@ class WaifuApi {
 						'one_time_download')) && !is_null($v); // @phpstan-ignore-line
 			},
 			ARRAY_FILTER_USE_BOTH
+		);
+		/**
+		 * Convert boolean params to "true" or "false" strings, because
+		 * http_build_query will convert them to 1 or 0 integers, which throws an API Exception
+		 */
+		$params = http_build_query(array_map(
+			fn($v)=>is_bool($v) ? ($v ? 'true' : 'false') : $v, // @phpstan-ignore-line
+			$params
 		));
 		if ($params !== '') {
 			$url .=  '?' . $params;
 		}
+
 		if (isset($args['url'])) {
 			$post_fields['url'] = $args['url'];
 		} elseif (isset($args['file'])) {

--- a/src/WaifuResponse.php
+++ b/src/WaifuResponse.php
@@ -2,17 +2,24 @@
 
 namespace ErnestMarcinko\WaifuVault;
 
+/**
+ * @phpstan-import-type WaifuResponseOptionsArgs from WaifuResponseOptions
+ */
 class WaifuResponse {
 	/**
 	 * @param string $token
 	 * @param string $url
-	 * @param bool $protected
 	 * @param int|string $retentionPeriod
+	 * @param WaifuResponseOptionsArgs|WaifuResponseOptions $options
 	 */
 	public function __construct(
-		public string     $token = '',
-		public string     $url = '',
-		public bool       $protected = false,
-		public int|string $retentionPeriod = ''
-	) {}
+		readonly public string     $token = '',
+		readonly public string     $url = '',
+		readonly public int|string $retentionPeriod = '',
+		public array|WaifuResponseOptions $options = array(),
+	) {
+		if (is_array($this->options)) {
+			$this->options = new WaifuResponseOptions(...$this->options);
+		}
+	}
 }

--- a/src/WaifuResponseOptions.php
+++ b/src/WaifuResponseOptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ErnestMarcinko\WaifuVault;
+
+/**
+ * @phpstan-type WaifuResponseOptionsArgs array{
+ *     hideFilename?: bool,
+ *     oneTimeDownload?: bool,
+ *     protected?: bool
+ * }
+ */
+readonly class WaifuResponseOptions {
+	/**
+	 * @param bool $hideFilename
+	 * @param bool $oneTimeDownload
+	 * @param bool $protected
+	 */
+	public function __construct(
+		public bool $hideFilename = false,
+		public bool $oneTimeDownload = false,
+		public bool $protected = false
+	) {}
+}

--- a/tests/WaifuTests/WaifuApiTest.php
+++ b/tests/WaifuTests/WaifuApiTest.php
@@ -128,8 +128,12 @@ class WaifuApiTest extends TestCase {
 		$args = [
 			"token" => "13b2485a-1010-4e3e-8f75-20f2a0c50b56",
 			"url" => "https://waifuvault.moe/f/1711098733870/image.jpg",
-			"protected" => false,
-			"retentionPeriod" => "300 days 10 hours 5 minutes 1 second"
+			"retentionPeriod" => "300 days 10 hours 5 minutes 1 second",
+			"options" => [
+				"hideFilename" => true,
+				"oneTimeDownload" => false,
+				"protected" => false,
+			]
 		];
 		$this->waifuResponse = new WaifuResponse(...$args);
 		$this->waifu = new WaifuApi();

--- a/tests/WaifuTests/WaifuRequestHandlerTest.php
+++ b/tests/WaifuTests/WaifuRequestHandlerTest.php
@@ -194,8 +194,12 @@ class WaifuRequestHandlerTest extends TestCase {
 		$args = [
 			"token" => "13b2485a-1010-4e3e-8f75-20f2a0c50b56",
 			"url" => "https://waifuvault.moe/f/1711098733870/image.jpg",
-			"protected" => false,
-			"retentionPeriod" => "300 days 10 hours 5 minutes 1 second"
+			"retentionPeriod" => "300 days 10 hours 5 minutes 1 second",
+			"options" => [
+				"hideFilename" => true,
+				"oneTimeDownload" => false,
+				"protected" => false,
+			]
 		];
 		$this->waifuResponse = new WaifuResponse(...$args);
 	}


### PR DESCRIPTION
- changed the WaifuResponse to support the new format
- added the one_time_download PUT param
- fixed an issue with the query parameter generator to support boolean values conversion to "true" & "false" instead of 1 & 0
- readme updates